### PR TITLE
nilrt.inc: Add kernel to BB_MULTI_PROVIDER_ALLOWED

### DIFF
--- a/conf/distro/nilrt.inc
+++ b/conf/distro/nilrt.inc
@@ -86,6 +86,7 @@ PREFERRED_PROVIDER_virtual/libgles1 ?= "mesa"
 PREFERRED_PROVIDER_virtual/libgles2 ?= "mesa"
 
 PREFERRED_PROVIDER_virtual/kernel ?= "linux-nilrt"
+BB_MULTI_PROVIDER_ALLOWED += "virtual/kernel"
 
 PREFERRED_RPROVIDER_java2-runtime = "openjdk-8"
 

--- a/recipes-core/packagegroups/packagefeed-ni-core.bb
+++ b/recipes-core/packagegroups/packagefeed-ni-core.bb
@@ -11,6 +11,7 @@ RDEPENDS:${PN} = "\
 	packagegroup-ni-crio \
 	packagegroup-ni-graphical \
 	packagegroup-ni-internal-deps \
+	packagegroup-ni-nohz-kernel \
 	packagegroup-ni-ptest \
 	packagegroup-ni-restoremode \
 	packagegroup-ni-runmode \


### PR DESCRIPTION
kernel.bbclass in oe-core now PROVIDES "virtual/kernel". This means that
alternate kernels like linux-nilrt-nohz/next/debug now all provide
"virtual/kernel" but since they're not PREFERRED_PROVIDER_virtual/kernel,
bitbake doesn't build them.

So add "virtual/kernel" to BB_MULTI_PROVIDER_ALLOWED.

### Testing
`packagegroup-ni-nohz-kernel` builds.